### PR TITLE
Check OPENAI_API_KEY before starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ npm install
 ```bash
 cp backend/.env.example backend/.env
 # Edit backend/.env and set OPENAI_API_KEY
+# The server will exit on startup if this variable is not defined
 ```
 
 3. Start the API server:

--- a/backend/openai.js
+++ b/backend/openai.js
@@ -3,6 +3,12 @@ import { OpenAI } from 'openai';
 
 dotenv.config();
 
+if (!process.env.OPENAI_API_KEY) {
+  console.error('Error: OPENAI_API_KEY is not set in the environment.');
+  console.error('Please create a .env file with your API key.');
+  process.exit(1);
+}
+
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY
 });


### PR DESCRIPTION
## Summary
- exit early if OPENAI_API_KEY is missing
- document that the server exits when the API key isn't provided

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_688c0a6b9e14832fbbb252408e823e02