### PR TITLE
Add env example and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cd backend
 npm install
 ```
 
-2. Create a `.env` file inside `backend/` with your OpenAI API key. Use `.env.example` as a template:
+2. Copy `backend/.env.example` to `backend/.env` and add your OpenAI API key:
 
 ```bash
 cp backend/.env.example backend/.env

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,1 @@
-# Copy this file to .env and provide your OpenAI API key
-OPENAI_API_KEY=your_openai_api_key_here
-# Optional: change the port
-PORT=4000
+OPENAI_API_KEY=your-key-here


### PR DESCRIPTION
## Summary
- simplify `backend/.env.example` placeholder line
- mention copying `.env.example` to `.env` in README

## Testing
- `npm test --prefix backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688c0b1bd5e0832fab7fb83caf2e642f