### PR TITLE
Fix CSS display for recomendacion

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -182,7 +182,7 @@ body.dark .message.abogado {
 
 .recomendacion {
     background-color: #40c240;
-    display: in;
+    display: inline-block;
     width: fit-content;
     padding-right: 0.5rem;
     padding-left: 0.5rem;


### PR DESCRIPTION
## Summary
- fix `.recomendacion` selector by using `display: inline-block`
- ensure CSS file ends with newline

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688c13023c80832fb45c37827f0a41f0