### PR TITLE
Fix pdf.js import

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,10 @@
   <!-- Librerías Globales -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-  <script src="assets/js/pdf.min.js"></script>
+  <script type="module">
+    import * as pdfjsLib from './assets/js/pdf.min.js';
+    window.pdfjsLib = pdfjsLib;
+  </script>
   <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,12 +1,7 @@
 import { analizarDictamen } from './parser.js';
+import * as pdfjsLib from '../assets/js/pdf.min.js';
 
 // === Soporte de TXT y PDF (OCR incluido) ===
-
-// Compatibilidad universal para PDF.js por CDN
-const pdfjsLib = window.pdfjsLib || window['pdfjs-dist/build/pdf'];
-if (!pdfjsLib) {
-  alert("PDF.js no está cargado correctamente. Verifica tu <script> en el HTML.");
-}
 
 function esTextoEscaso(txt) {
   // Menos de 50 palabras = probablemente es imagen


### PR DESCRIPTION
## Summary
- expose `pdfjsLib` via module script in HTML
- import pdf.js from `main.js` instead of using `window` globals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c2471ef78832faba45f8b625c8643