### PR TITLE
Improve error handling in frontend

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -157,7 +157,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // === CAMBIO AQUÍ: lee txt o pdf con o sin OCR ===
     const texto = await obtenerTextoArchivo(dictamenInput.files[0]);
-    estructuraDictamen = await analizarDictamen(texto);
+    try {
+      estructuraDictamen = await analizarDictamen(texto);
+    } catch (err) {
+      cargandoEl.classList.add('hidden');
+      alert(err.message || 'Error al analizar dictamen');
+      return;
+    }
 
     const resp = await fetch('http://localhost:4000/api/preguntas', {
       method:  'POST',

--- a/js/parser.js
+++ b/js/parser.js
@@ -7,6 +7,11 @@ export async function analizarDictamen(texto) {
 
   const data = await res.json();
 
+  if (!res.ok || !data.estructura) {
+    const msg = data.error || 'Error al analizar dictamen';
+    throw new Error(msg);
+  }
+
   const partes = data.estructura;
 
   const resultado = {
@@ -21,6 +26,9 @@ export async function analizarDictamen(texto) {
 }
 
 function extraer(titulo, texto) {
+  if (!texto) {
+    return 'No encontrado';
+  }
   const regex = new RegExp(`${titulo}:?\\s*([\\s\\S]*?)(\\n\\n|$)`, 'i');
   const match = texto.match(regex);
   return match ? match[1].trim() : 'No encontrado';


### PR DESCRIPTION
## Summary
- make analizarDictamen throw when backend returns an error
- guard against undefined text in extractor
- catch errors in main.js when analyzing dictamen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c2ea44514832f919c307b1587d9fa