### PR TITLE
Improve PDF export line wrapping

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -236,6 +236,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const fecha    = new Date().toLocaleString();
     const { jsPDF } = window.jspdf;
     const pdf       = new jsPDF();
+    const lineHeight = 10;
+    const pageLimit  = 280;
     let y = 10;
     pdf.text('PeritIA - Simulación Judicial', 10, y); y += 10;
     pdf.text(`Archivo: ${filename}.txt`, 10, y); y += 10;
@@ -245,10 +247,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
     historial.forEach((item, idx) => {
       const evaluacion = item.evaluacion.replace(/\n/g, ' ');
-      pdf.text(`Pregunta ${idx + 1}: ${item.pregunta}`, 10, y); y += 10;
-      pdf.text(`Respuesta: ${item.respuesta}`, 10, y); y += 10;
-      pdf.text(`Evaluación: ${evaluacion}`, 10, y); y += 20;
-      if (y > 280) { pdf.addPage(); y = 10; }
+      let lines = pdf.splitTextToSize(`Pregunta ${idx + 1}: ${item.pregunta}`, 180);
+      pdf.text(lines, 10, y);
+      y += lines.length * lineHeight;
+      if (y > pageLimit) { pdf.addPage(); y = 10; }
+
+      lines = pdf.splitTextToSize(`Respuesta: ${item.respuesta}`, 180);
+      pdf.text(lines, 10, y);
+      y += lines.length * lineHeight;
+      if (y > pageLimit) { pdf.addPage(); y = 10; }
+
+      lines = pdf.splitTextToSize(`Evaluación: ${evaluacion}`, 180);
+      pdf.text(lines, 10, y);
+      y += lines.length * lineHeight;
+      y += lineHeight;
+      if (y > pageLimit) { pdf.addPage(); y = 10; }
     });
 
     pdf.save(`simulacion_${filename}.pdf`);
@@ -262,12 +275,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const fecha = new Date().toLocaleString();
     const { jsPDF } = window.jspdf;
     const pdf       = new jsPDF();
+    const lineHeight = 10;
+    const pageLimit  = 280;
     let y = 10;
     pdf.text('Preguntas Generadas', 10, y); y += 10;
     pdf.text(`Fecha: ${fecha}`, 10, y); y += 20;
     preguntasActuales.forEach((q, idx) => {
-      pdf.text(`${idx + 1}. ${q}`, 10, y); y += 10;
-      if (y > 280) { pdf.addPage(); y = 10; }
+      const lines = pdf.splitTextToSize(`${idx + 1}. ${q}`, 180);
+      pdf.text(lines, 10, y);
+      y += lines.length * lineHeight;
+      if (y > pageLimit) { pdf.addPage(); y = 10; }
     });
     pdf.save(`preguntas_generadas_${fecha.split(',')[0].replace(/\//g,'-')}.pdf`);
   });


### PR DESCRIPTION
## Summary
- wrap question, answer and evaluation text when exporting history
- wrap generated questions when exporting questions-only
- add `lineHeight` and `pageLimit` constants to handle spacing and page breaks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c38028794832fa3085390e4423937