### PR TITLE
Store and display recent dictamenes

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,20 +33,7 @@
 
 <div class="flex-grow mt-6 overflow-y-auto custom-scrollbar -mr-3 pr-3">
                  <h3 class="px-3 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Dictamenes Recientes</h3>
-                <nav class="flex flex-col gap-1">
-                    <a href="#" class="px-3 py-2.5 rounded-lg text-sm font-medium hover:bg-white/5 transition-colors duration-200 truncate">
-                        Dictamen 11
-                    </a>
-                    <a href="#" class="px-3 py-2.5 rounded-lg text-sm font-medium hover:bg-white/5 transition-colors duration-200 truncate">
-                        Dictamen 2
-                    </a>
-                    <a href="#" class="px-3 py-2.5 rounded-lg text-sm font-medium hover:bg-white/5 transition-colors duration-200 truncate">
-                        Dictamen 3
-                    </a>
-                     <a href="#" class="px-3 py-2.5 rounded-lg text-sm font-medium hover:bg-white/5 transition-colors duration-200 truncate">
-                        Dictamen 4
-                    </a>
-                </nav>
+                <nav id="dictamenesRecientes" class="flex flex-col gap-1"></nav>
             </div>
 
     </aside>


### PR DESCRIPTION
## Summary
- Save analyzed dictamens to backend API
- Load recent dictamens on page load and display them in sidebar
- Add click handler to fetch and show selected dictamen

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9cb8641e0832fa539aa114ac369bd