### PR TITLE
feat: centralize API base URL

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,5 @@
+export const API_BASE_URL =
+  (typeof import.meta !== 'undefined' && import.meta.env && (import.meta.env.VITE_API_BASE_URL || import.meta.env.API_BASE_URL)) ||
+  (typeof process !== 'undefined' && process.env && process.env.API_BASE_URL) ||
+  (typeof window !== 'undefined' && window.API_BASE_URL) ||
+  'http://localhost:4000';

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from './config.js';
 import { analizarDictamen } from './parser.js';
 import * as pdfjsLib from '../assets/js/pdf.min.js';
 pdfjsLib.GlobalWorkerOptions.workerSrc = '../assets/js/pdf.worker.min.js';
@@ -77,7 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
   async function cargarDictamenesRecientes() {
     if (!dictamenesRecientesNav) return;
     try {
-      const resp = await fetch('http://localhost:4000/api/dictamenes');
+      const resp = await fetch(`${API_BASE_URL}/api/dictamenes`);
       if (!resp.ok) {
         const msg = await resp.text();
         throw new Error(msg || 'Error al cargar dictámenes');
@@ -92,7 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
         a.addEventListener('click', async (e) => {
           e.preventDefault();
           try {
-            const res = await fetch(`http://localhost:4000/api/dictamenes/${d.id}`);
+            const res = await fetch(`${API_BASE_URL}/api/dictamenes/${d.id}`);
             if (!res.ok) {
               const msg = await res.text();
               throw new Error(msg || 'Error al obtener dictamen');
@@ -206,7 +207,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    await fetch('http://localhost:4000/api/dictamenes', {
+    await fetch(`${API_BASE_URL}/api/dictamenes`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -217,7 +218,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     cargarDictamenesRecientes();
 
-    const resp = await fetch('http://localhost:4000/api/preguntas', {
+    const resp = await fetch(`${API_BASE_URL}/api/preguntas`, {
       method:  'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -255,7 +256,7 @@ document.addEventListener('DOMContentLoaded', () => {
       <p>🧠 Evaluando respuesta...</p>`;
 
     const preguntaActual = preguntasActuales[preguntaIndex];
-    const res = await fetch('http://localhost:4000/api/evaluar', {
+    const res = await fetch(`${API_BASE_URL}/api/evaluar`, {
       method:  'POST',
       headers: { 'Content-Type': 'application/json' },
       body:    JSON.stringify({ respuesta })

--- a/js/parser.js
+++ b/js/parser.js
@@ -1,5 +1,6 @@
+import { API_BASE_URL } from './config.js';
 export async function analizarDictamen(texto) {
-  const res = await fetch('http://localhost:4000/api/analizar', {
+  const res = await fetch(`${API_BASE_URL}/api/analizar`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ texto })


### PR DESCRIPTION
## Summary
- add configurable `API_BASE_URL` constant
- replace hardcoded URLs in frontend fetch calls

## Testing
- `npm --prefix backend test`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e70b2cf4832f8a59b565970a24c0