### PR TITLE
Add error handling tests for API routes

### DIFF
--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -70,6 +70,34 @@ describe('API routes', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ resultado: 'resultado de prueba' });
   });
+
+  test('/api/analizar handles OpenAI errors', async () => {
+    mockGenerarRespuestaGPT.mockRejectedValue(new Error('fallo'));
+    const res = await request(app)
+      .post('/api/analizar')
+      .send({ texto: 'dictamen' });
+
+    expect(res.status).toBe(500);
+  });
+
+  test('/api/preguntas handles OpenAI errors', async () => {
+    mockGenerarRespuestaGPT.mockRejectedValue(new Error('fallo'));
+    const estructura = { hechos: '', metodologia: '', conclusiones: '' };
+    const res = await request(app)
+      .post('/api/preguntas')
+      .send({ modo: 'actor', estructura, tono: 'academico' });
+
+    expect(res.status).toBe(500);
+  });
+
+  test('/api/evaluar handles OpenAI errors', async () => {
+    mockGenerarRespuestaGPT.mockRejectedValue(new Error('fallo'));
+    const res = await request(app)
+      .post('/api/evaluar')
+      .send({ respuesta: 'ok' });
+
+    expect(res.status).toBe(500);
+  });
 });
 
 describe('Dictamenes API', () => {
@@ -115,5 +143,17 @@ describe('Dictamenes API', () => {
 
     const resNotFound = await request(app).get('/api/dictamenes/999');
     expect(resNotFound.status).toBe(404);
+  });
+
+  test('POST /api/dictamenes with invalid data returns 400', async () => {
+    const res = await request(app)
+      .post('/api/dictamenes')
+      .send({ texto: 123 });
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /api/dictamenes/:id with invalid id returns 400', async () => {
+    const res = await request(app).get('/api/dictamenes/abc');
+    expect(res.status).toBe(400);
   });
 });


### PR DESCRIPTION
## Summary
- extend backend tests to cover OpenAI error responses in `/api/analizar`, `/api/preguntas`, and `/api/evaluar`
- add validation tests for `/api/dictamenes` endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ebe09c90832fb71aa9651acf3239