### PR TITLE
Handle missing OpenAI client gracefully

### DIFF
--- a/backend/openai.js
+++ b/backend/openai.js
@@ -12,12 +12,11 @@ if (process.env.OPENAI_API_KEY) {
 } else if (process.env.NODE_ENV !== 'test') {
   console.error('Error: OPENAI_API_KEY is not set in the environment.');
   console.error('Please create a .env file with your API key.');
-  process.exit(1);
 }
 
 export async function generarRespuestaGPT(prompt) {
   if (!openai) {
-    throw new Error('OpenAI client not initialized');
+    throw new Error('OpenAI client not initialized. Set OPENAI_API_KEY.');
   }
   const chatCompletion = await openai.chat.completions.create({
     model: 'gpt-4o',

--- a/backend/server.js
+++ b/backend/server.js
@@ -72,6 +72,9 @@ Texto del dictamen:
     const respuesta = await generarRespuestaGPT(prompt);
     res.json({ estructura: respuesta });
   } catch (err) {
+    if (err.message.includes('OpenAI client not initialized')) {
+      return res.status(503).json({ error: 'Servicio no disponible' });
+    }
     res.status(500).json({ error: err.message });
   }
 });
@@ -87,6 +90,9 @@ app.post('/api/preguntas', async (req, res) => {
 
     res.json({ preguntas });
   } catch (err) {
+    if (err.message.includes('OpenAI client not initialized')) {
+      return res.status(503).json({ error: 'Servicio no disponible' });
+    }
     res.status(500).json({ error: err.message });
   }
 });
@@ -115,6 +121,9 @@ Devuelve una tabla y una recomendación final.
     const resultado = await generarRespuestaGPT(prompt);
     res.json({ resultado });
   } catch (err) {
+    if (err.message.includes('OpenAI client not initialized')) {
+      return res.status(503).json({ error: 'Servicio no disponible' });
+    }
     res.status(500).json({ error: err.message });
   }
 });

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -80,6 +80,17 @@ describe('API routes', () => {
     expect(res.status).toBe(500);
   });
 
+  test('/api/analizar returns 503 when OpenAI is unavailable', async () => {
+    mockGenerarRespuestaGPT.mockRejectedValue(
+      new Error('OpenAI client not initialized')
+    );
+    const res = await request(app)
+      .post('/api/analizar')
+      .send({ texto: 'dictamen' });
+
+    expect(res.status).toBe(503);
+  });
+
   test('/api/preguntas handles OpenAI errors', async () => {
     mockGenerarRespuestaGPT.mockRejectedValue(new Error('fallo'));
     const estructura = { hechos: '', metodologia: '', conclusiones: '' };
@@ -90,6 +101,18 @@ describe('API routes', () => {
     expect(res.status).toBe(500);
   });
 
+  test('/api/preguntas returns 503 when OpenAI is unavailable', async () => {
+    mockGenerarRespuestaGPT.mockRejectedValue(
+      new Error('OpenAI client not initialized')
+    );
+    const estructura = { hechos: '', metodologia: '', conclusiones: '' };
+    const res = await request(app)
+      .post('/api/preguntas')
+      .send({ modo: 'actor', estructura, tono: 'academico' });
+
+    expect(res.status).toBe(503);
+  });
+
   test('/api/evaluar handles OpenAI errors', async () => {
     mockGenerarRespuestaGPT.mockRejectedValue(new Error('fallo'));
     const res = await request(app)
@@ -97,6 +120,17 @@ describe('API routes', () => {
       .send({ respuesta: 'ok' });
 
     expect(res.status).toBe(500);
+  });
+
+  test('/api/evaluar returns 503 when OpenAI is unavailable', async () => {
+    mockGenerarRespuestaGPT.mockRejectedValue(
+      new Error('OpenAI client not initialized')
+    );
+    const res = await request(app)
+      .post('/api/evaluar')
+      .send({ respuesta: 'ok' });
+
+    expect(res.status).toBe(503);
   });
 });
 


### PR DESCRIPTION
## Summary
- Stop terminating the process when `OPENAI_API_KEY` is missing and instead throw a descriptive error from `generarRespuestaGPT`
- Return HTTP 503 when OpenAI is unavailable in analizar, preguntas, and evaluar endpoints
- Extend tests to cover service unavailability scenarios

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ed411d4c832f98a4a6cb28291441