### PR TITLE
Manejar errores al generar preguntas

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -217,24 +217,31 @@ document.addEventListener('DOMContentLoaded', () => {
       })
     });
     cargarDictamenesRecientes();
-
-    const resp = await fetch(`${API_BASE_URL}/api/preguntas`, {
-      method:  'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        modo:       modoSimulacionSelect.value,
-        estructura: estructuraDictamen,
-        tono:       modoAcademico ? 'academico' : 'litigio'
-      })
-    });
-    if (!resp.ok) {
-      const msg = await resp.text();
+    try {
+      const resp = await fetch(`${API_BASE_URL}/api/preguntas`, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          modo:       modoSimulacionSelect.value,
+          estructura: estructuraDictamen,
+          tono:       modoAcademico ? 'academico' : 'litigio'
+        })
+      });
+      if (!resp.ok) {
+        throw new Error(await resp.text());
+      }
+      const { preguntas } = await resp.json();
+      if (!preguntas.length) {
+        cargandoEl.classList.add('hidden');
+        alert('No se pudieron generar preguntas');
+        return;
+      }
+      preguntasActuales = preguntas;
+    } catch (err) {
       cargandoEl.classList.add('hidden');
-      alert(msg || 'Error al generar preguntas');
+      alert('No se pudieron generar preguntas');
       return;
     }
-    const { preguntas } = await resp.json();
-    preguntasActuales    = preguntas;
 
     cargandoEl.classList.add('hidden');
     mostrarPregunta();


### PR DESCRIPTION
## Summary
- Maneja errores al solicitar preguntas al backend envolviendo la petición en un bloque `try/catch` y mostrando un mensaje genérico si falla.
- Verifica que la respuesta contenga preguntas antes de iniciar la simulación y notifica al usuario si no hay ninguna.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f645a54c832fa2d9f035b4621ab3