### PR TITLE
Mostrar nombre del dictamen cargado

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 
     <!-- Controles de PeritIA arriba del chat -->
     <div class="p-3">
-      <div class="max-w-4xl mx-auto flex flex-col md:flex-row md:items-center justify-between">
+  <div class="max-w-4xl mx-auto flex flex-col md:flex-row md:items-center justify-between">
 
 <div class="file-input">
     <input
@@ -84,6 +84,7 @@
         </svg>
         <span>Cargar dictamen</span></label
       >
+      <span id="dictamenCargado" class="ml-2 text-sm"></span>
     </div>
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -68,6 +68,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnPreguntas         = document.getElementById('exportarPreguntasBtn');
   const dictamenesRecientesNav = document.getElementById('dictamenesRecientes');
 
+  dictamenInput.addEventListener('change', () => {
+    const indicador = document.getElementById('dictamenCargado');
+    indicador.textContent = '';
+    if (dictamenInput.files[0]) {
+      indicador.textContent = `Dictamen cargado: ${dictamenInput.files[0].name}`;
+    }
+  });
+
   // — Estado interno —
   let estructuraDictamen = null;
   let preguntasActuales  = [];
@@ -182,6 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // — Iniciar simulación —
   iniciarBtn.addEventListener('click', async () => {
+    document.getElementById('dictamenCargado').textContent = '';
     chatContainer.innerHTML      = '';
     preguntasActuales            = [];
     preguntaIndex                = 0;


### PR DESCRIPTION
## Summary
- Agrega un indicador junto al input de archivo para mostrar el nombre del dictamen cargado
- Limpia el indicador al iniciar una simulación

## Testing
- `npm test` *(falla: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fa6eb058832fa26a992cf4666a48