### PR TITLE
Add dictamen load status icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
         </svg>
         <span>Cargar dictamen</span></label
       >
-      <span id="dictamenCargado" class="ml-2 text-sm"></span>
+      <span id="dictamenIcon" class="ml-2 text-xl"></span>
     </div>
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -68,13 +68,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnPreguntas         = document.getElementById('exportarPreguntasBtn');
   const dictamenesRecientesNav = document.getElementById('dictamenesRecientes');
 
-  dictamenInput.addEventListener('change', () => {
-    const indicador = document.getElementById('dictamenCargado');
-    indicador.textContent = '';
-    if (dictamenInput.files[0]) {
-      indicador.textContent = `Dictamen cargado: ${dictamenInput.files[0].name}`;
-    }
-  });
+    dictamenInput.addEventListener('change', async () => {
+      const indicador = document.getElementById('dictamenIcon');
+      const file = dictamenInput.files[0];
+      if (file) {
+        try {
+          await obtenerTextoArchivo(file);
+          indicador.innerHTML = '<span class="text-green-500">✔️</span>';
+        } catch (err) {
+          indicador.innerHTML = '<span class="text-red-500">✖️</span>';
+        }
+      } else {
+        indicador.innerHTML = '<span class="text-red-500">✖️</span>';
+      }
+    });
 
   // — Estado interno —
   let estructuraDictamen = null;
@@ -190,7 +197,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // — Iniciar simulación —
   iniciarBtn.addEventListener('click', async () => {
-    document.getElementById('dictamenCargado').textContent = '';
+    const indicador = document.getElementById('dictamenIcon');
+    indicador.innerHTML = '';
     chatContainer.innerHTML      = '';
     preguntasActuales            = [];
     preguntaIndex                = 0;


### PR DESCRIPTION
## Summary
- replace placeholder span with icon container next to dictamen input
- show green or red icon when dictamen file loads or fails
- clear icon when starting new simulation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fdb4cadc832f9508c04c8abf732b