### PR TITLE
Handle question generation errors in iniciarBtn

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -249,14 +249,12 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       const { preguntas } = await resp.json();
       if (!preguntas.length) {
-        cargandoEl.classList.add('hidden');
-        alert('No se pudieron generar preguntas');
-        return;
+        throw new Error('No se pudieron generar preguntas');
       }
       preguntasActuales = preguntas;
     } catch (err) {
       cargandoEl.classList.add('hidden');
-      alert('No se pudieron generar preguntas');
+      alert(err.message || 'No se pudieron generar preguntas');
       return;
     }
 


### PR DESCRIPTION
## Summary
- Throw an error when question generation returns no results
- Provide detailed alert messages for question generation failures

## Testing
- ⚠️ `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ba006b396c832fa892948ff40b4634