### PR TITLE
Muestra mensaje si falta OPENAI_API_KEY

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -244,6 +244,11 @@ document.addEventListener('DOMContentLoaded', () => {
           tono:       modoAcademico ? 'academico' : 'litigio'
         })
       });
+      if (resp.status === 503) {
+        cargandoEl.classList.add('hidden');
+        alert('Configura la variable OPENAI_API_KEY en el servidor.');
+        return;
+      }
       if (!resp.ok) {
         throw new Error(await resp.text());
       }


### PR DESCRIPTION
## Summary
- Detecta error 503 al solicitar preguntas
- Guía al usuario a configurar `OPENAI_API_KEY` en el servidor

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4c07cd40832fa747d1d91e0ebce2