### PR TITLE
Handle dictamen fetch errors gracefully

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -122,6 +122,8 @@ document.addEventListener('DOMContentLoaded', () => {
         dictamenesRecientesNav.appendChild(a);
       });
     } catch (err) {
+      cargandoEl.classList.add('hidden');
+      alert('No se puede conectar con el servidor backend.');
       console.error('Error cargando dictamenes', err);
     }
   }
@@ -224,15 +226,21 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    await fetch(`${API_BASE_URL}/api/dictamenes`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        texto,
-        estructura: estructuraDictamen,
-        fecha: new Date().toISOString()
-      })
-    });
+    try {
+      await fetch(`${API_BASE_URL}/api/dictamenes`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          texto,
+          estructura: estructuraDictamen,
+          fecha: new Date().toISOString()
+        })
+      });
+    } catch (err) {
+      cargandoEl.classList.add('hidden');
+      alert('No se puede conectar con el servidor backend.');
+      return;
+    }
     cargarDictamenesRecientes();
     try {
       const resp = await fetch(`${API_BASE_URL}/api/preguntas`, {


### PR DESCRIPTION
## Summary
- alert users when dictamen list loading fails and hide spinner
- catch failures posting dictamenes and notify when backend is unreachable

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ba53d64a3c832fad298fed13b30304