### PR TITLE
docs: document backend URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,20 @@ The server listens on `http://localhost:4000` by default. You can change the por
 ## Frontend
 
 Open `index.html` in your browser. The page will communicate with the backend server to analyze text and generate questions.
+
+## Configuración del backend
+
+El frontend obtiene la URL del servidor desde variables de entorno. Durante el
+desarrollo, Vite usa `VITE_API_BASE_URL` y en la versión compilada se emplea
+`API_BASE_URL`. Ajusta estos valores si el backend corre en otra máquina o si
+el acceso se realiza por **HTTPS**.
+
+Ejemplos de uso:
+
+```bash
+# Ejecutar el frontend en modo desarrollo apuntando a un backend remoto
+VITE_API_BASE_URL="http://192.168.1.10:4000" npm run dev
+
+# Compilar la aplicación especificando un backend con HTTPS
+API_BASE_URL="https://api.midominio.com" npm run build
+```


### PR DESCRIPTION
## Summary
- explain how the frontend reads backend URL from `VITE_API_BASE_URL`/`API_BASE_URL`
- show examples of setting these variables when running the dev server or building

## Testing
- `npm test` (fails: Error: no test specified)
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba66dd2fa4832fa5af4afa06a154ce