### PR TITLE
Replace OpenAI API key placeholder

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,5 @@
 # OpenAI API key
-OPENAI_API_KEY=
+OPENAI_API_KEY=<your_key_here>
 
 # Optional: port to run the server (defaults to 4000)
 # PORT=4000


### PR DESCRIPTION
## Summary
- Replace backend .env example with neutral placeholder

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68baef524d30832fb856abd5fb9f120c