### PR TITLE
Handle network errors with status alerts

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -74,7 +74,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (!resp.ok) throw new Error('API no disponible');
       return true;
     } catch (err) {
-      alert('El servidor no está disponible');
+      const { status, statusText } = err.response || {};
+      if (status) {
+        alert(`Error ${status}: ${statusText}`);
+      } else {
+        alert(err.message || 'El servidor no está disponible');
+      }
+      console.error(err);
       [iniciarBtn, evaluarBtn, btnHistorial, btnPreguntas].forEach(btn => btn && (btn.disabled = true));
       return false;
     }
@@ -153,7 +159,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             } else {
               alert(`No se pudo conectar con ${detalleUrl}: ${err.message}`);
             }
-            console.error(err.stack || err);
+            console.error(err);
             return;
           }
 
@@ -191,7 +197,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             } else {
               alert(`No se pudo conectar con ${preguntasUrl}: ${err.message}`);
             }
-            console.error(err.stack || err);
+            console.error(err);
           }
         });
         dictamenesRecientesNav.appendChild(a);
@@ -204,7 +210,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       } else {
         alert(`No se pudo conectar con ${url}: ${err.message}`);
       }
-      console.error(err.stack || err);
+      console.error(err);
     }
   }
 
@@ -325,7 +331,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       } else {
         alert(`No se pudo conectar con ${dictamenUrl}: ${err.message}`);
       }
-      console.error(err.stack || err);
+      console.error(err);
       return;
     }
     cargarDictamenesRecientes();
@@ -361,7 +367,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       } else {
         alert(`No se pudo conectar con ${preguntasUrl}: ${err.message}`);
       }
-      console.error(err.stack || err);
+      console.error(err);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Show alert with HTTP status and message when API checks fail
- Log full error in browser console for debugging

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c39f4d07a0832f82caecbc5532bc8b