### PR TITLE
feat: handle preguntas get method

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -79,6 +79,10 @@ Texto del dictamen:
   }
 });
 
+app.get('/api/preguntas', (_, res) =>
+  res.status(405).json({ error: 'Use POST en lugar de GET' })
+);
+
 app.post('/api/preguntas', async (req, res) => {
   try {
     const { modo, estructura, tono } = req.body;

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -61,6 +61,12 @@ describe('API routes', () => {
     expect(res.body).toEqual({ preguntas: ['pregunta1', 'pregunta2'] });
   });
 
+  test('GET /api/preguntas returns 405', async () => {
+    const res = await request(app).get('/api/preguntas');
+    expect(res.status).toBe(405);
+    expect(res.body).toEqual({ error: 'Use POST en lugar de GET' });
+  });
+
   test('/api/evaluar returns resultado', async () => {
     mockGenerarRespuestaGPT.mockResolvedValue('resultado de prueba');
     const res = await request(app)


### PR DESCRIPTION
## Summary
- reject GET requests to `/api/preguntas` with a 405 error instructing to use POST
- test that GET `/api/preguntas` responds with 405 and proper message

## Testing
- `cd backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68c3a211a8dc832fa657d177396fcbcd