### PR TITLE
docs: add cross-platform API_BASE_URL examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,27 @@ puede configurarse de dos formas:
 
 Ajusta estos valores si el backend corre en otra máquina o si se accede por
 **HTTPS**.
+
+## Ejemplos para establecer `API_BASE_URL`
+
+Cuando se sirve el frontend con herramientas como `live-server`, la URL del
+backend puede definirse mediante la variable de entorno `VITE_API_BASE_URL`
+(o `API_BASE_URL` en producción). Los comandos varían según la plataforma:
+
+### Linux/macOS (Bash)
+
+```bash
+VITE_API_BASE_URL=http://localhost:4000 npx live-server
+```
+
+### Windows CMD
+
+```cmd
+set VITE_API_BASE_URL=http://localhost:4000 && npx live-server
+```
+
+### PowerShell
+
+```powershell
+$env:VITE_API_BASE_URL="http://localhost:4000"; npx live-server
+```


### PR DESCRIPTION
## Summary
- document API_BASE_URL usage when serving the frontend
- add Linux/macOS, Windows CMD, and PowerShell examples

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a332cfa4832faaa4971d5647ac55