### PR TITLE
Add cross-env frontend script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ puede configurarse de dos formas:
    npm start
 
    # Abrir el frontend con Live Server apuntando al backend local
-   VITE_API_BASE_URL="http://localhost:4000" npx live-server
+   npm run frontend
    ```
 
 2. **Inyección en `window.API_BASE_URL`**. Para servir archivos estáticos, basta
@@ -66,6 +66,13 @@ Ajusta estos valores si el backend corre en otra máquina o si se accede por
 Cuando se sirve el frontend con herramientas como `live-server`, la URL del
 backend puede definirse mediante la variable de entorno `VITE_API_BASE_URL`
 (o `API_BASE_URL` en producción). Los comandos varían según la plataforma:
+
+### Comando unificado
+
+```bash
+npm run frontend
+```
+
 
 ### Linux/macOS (Bash)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.4"
+      },
+      "devDependencies": {
+        "cross-env": "^10.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -25,6 +28,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -370,6 +380,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "frontend": "cross-env VITE_API_BASE_URL=http://localhost:4000 live-server"
   },
   "keywords": [],
   "author": "",
@@ -17,5 +18,8 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.4"
+  },
+  "devDependencies": {
+    "cross-env": "^10.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add cross-platform `frontend` npm script using cross-env
- document `npm run frontend` in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c46f871a04832facc5e69d1b41c5f9