### PR TITLE
Add API health check and frontend validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ npm start
 
 The server listens on `http://localhost:4000` by default. You can change the port by setting the `PORT` variable in the `.env` file.
 
+### Health check
+
+The backend exposes a simple endpoint to verify that it is running:
+
+```
+GET /api/health
+```
+
+It responds with:
+
+```json
+{ "status": "ok" }
+```
+
 ## Frontend
 
 Open `index.html` in your browser. The page will communicate with the backend server to analyze text and generate questions.

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,10 @@ export const app = express();
 app.use(cors());
 app.use(express.json());
 
+app.get('/api/health', (_, res) => {
+  res.json({ status: 'ok' });
+});
+
 app.post('/api/dictamenes', async (req, res) => {
   try {
     const { texto, estructura, fecha } = req.body;

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -40,6 +40,12 @@ beforeEach(async () => {
 });
 
 describe('API routes', () => {
+  test('GET /api/health returns status ok', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+
   test('/api/analizar returns estructura', async () => {
     mockGenerarRespuestaGPT.mockResolvedValue('estructura de prueba');
     const res = await request(app)

--- a/js/main.js
+++ b/js/main.js
@@ -70,16 +70,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   async function checkApi() {
     try {
-      const resp = await fetch(`${API_BASE_URL}/api/dictamenes`, { method: 'HEAD' });
-      if (!resp.ok) throw new Error('API no disponible');
+      const resp = await fetch(`${API_BASE_URL}/api/health`);
+      if (!resp.ok) throw new Error('Servidor no disponible');
       return true;
     } catch (err) {
-      const { status, statusText } = err.response || {};
-      if (status) {
-        alert(`Error ${status}: ${statusText}`);
-      } else {
-        alert(err.message || 'El servidor no está disponible');
-      }
+      alert('El servidor no está disponible');
       console.error(err);
       [iniciarBtn, evaluarBtn, btnHistorial, btnPreguntas].forEach(btn => btn && (btn.disabled = true));
       return false;


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint to return status information
- verify server availability from frontend and alert on failure
- document health check in README and cover with tests

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c46f89a3d0832f99e35842ea44ef9b