### PR TITLE
refactor: lazily initialize OpenAI client

### DIFF
--- a/backend/openai.js
+++ b/backend/openai.js
@@ -3,21 +3,22 @@ import { OpenAI } from 'openai';
 
 dotenv.config();
 
-let openai = null;
+let client = null;
 
-if (process.env.OPENAI_API_KEY) {
-  openai = new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY
-  });
-} else if (process.env.NODE_ENV !== 'test') {
-  console.error('Error: OPENAI_API_KEY is not set in the environment.');
-  console.error('Please create a .env file with your API key.');
+export function getClient() {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error(
+      'OpenAI client not initialized: missing OPENAI_API_KEY environment variable'
+    );
+  }
+  if (!client) {
+    client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  }
+  return client;
 }
 
 export async function generarRespuestaGPT(prompt) {
-  if (!openai) {
-    throw new Error('OpenAI client not initialized. Set OPENAI_API_KEY.');
-  }
+  const openai = getClient();
   const timeoutMs = Number(process.env.OPENAI_TIMEOUT_MS) || 15000;
   const openaiPromise = openai.chat.completions.create({
     model: 'gpt-4o',


### PR DESCRIPTION
## Summary
- lazily create OpenAI client via `getClient()`
- throw descriptive error when `OPENAI_API_KEY` is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c49c4a25ac832f9f01b399f28d5e0c