### PR TITLE
docs: clarify separate server and frontend startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ It responds with:
 { "status": "ok" }
 ```
 
+## Ejecutar backend y frontend por separado
+
+Si prefieres iniciar cada parte manualmente, utiliza dos terminales diferentes:
+
+```bash
+# Terminal 1: iniciar el servidor
+cd backend && npm start
+```
+
+```bash
+# Terminal 2: servir el frontend
+npx live-server
+```
+
+> **Advertencia:** el backend lee `OPENAI_API_KEY` desde `backend/.env`. Si cambias este valor, reinicia el servidor para aplicar la configuración.
+
 ## Frontend
 
 Open `index.html` in your browser. The page will communicate with the backend server to analyze text and generate questions.


### PR DESCRIPTION
## Summary
- Add instructions for running server and frontend in separate terminals
- Warn about `OPENAI_API_KEY` sourcing from `backend/.env` and need to restart after changes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c49c4b6dd8832fae65649a3bb0b96e