### PR TITLE
docs: explain dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ After modifying `backend/.env`, restart the backend so that the new settings tak
 npm run dev
 ```
 
-This command uses `cross-env` to set `VITE_API_BASE_URL`, so it works the same on Windows, macOS, and Linux.
+This command launches both the backend and a live server for the frontend using `concurrently`. `cross-env` sets `VITE_API_BASE_URL`, so it works the same on Windows, macOS, and Linux. If you prefer to run each part manually, you'll need two terminals (see the section below).
 
 The server listens on `http://127.0.0.1:4000` by default. On some Windows setups `localhost` may fail to resolve, so using the numeric IP avoids that problem. You can change the port by setting the `PORT` variable in the `.env` file.
 


### PR DESCRIPTION
## Summary
- document `npm run dev` as a concurrent backend/frontend launcher and mention manual setup requires two terminals

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a9d53cb4832faaff98d41681de83