### PR TITLE
feat: validate openai key at startup

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,10 @@ import { generarPromptPreguntas } from './prompts.js';
 import { agregarDictamen, listarDictamenes, obtenerDictamen } from './historial.js';
 
 dotenv.config();
+if (!process.env.OPENAI_API_KEY) {
+  console.error('Falta la variable de entorno OPENAI_API_KEY');
+  process.exit(1);
+}
 console.log('OPENAI_API_KEY detected:', !!process.env.OPENAI_API_KEY);
 
 export const app = express();

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -1,6 +1,8 @@
 import request from 'supertest';
 import { jest } from '@jest/globals';
 
+process.env.OPENAI_API_KEY = 'test-key';
+
 // Mock generarRespuestaGPT to avoid calling OpenAI
 const mockGenerarRespuestaGPT = jest.fn();
 


### PR DESCRIPTION
## Summary
- fail fast if OPENAI_API_KEY is missing when starting backend
- set test environment variable to satisfy new check

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68c4a9d5d930832f8f3c408451daa843