### PR TITLE
Mejorar manejo de errores en fetch

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -81,9 +81,11 @@ document.addEventListener('DOMContentLoaded', async () => {
           serverMessage = await err.response.text();
         } catch {}
       }
-      alert(serverMessage ? `Error ${status}: ${statusText} - ${serverMessage}` : `Error ${status}: ${statusText}`);
+      alert(serverMessage
+        ? `Error ${status} ${statusText} al solicitar ${url}: ${serverMessage}`
+        : `Error ${status} ${statusText} al solicitar ${url}`);
     } else {
-      alert(`Failed to fetch${url ? ` ${url}` : ''}: ${err.message}`);
+      alert(`Error al solicitar ${url}: ${err.message}. ¿Ejecutaste npm start en backend y definiste OPENAI_API_KEY?`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Mostrar la URL y el código de estado en los errores de fetch
- Sugerir iniciar el backend y definir OPENAI_API_KEY cuando no hay respuesta

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check js/main.js` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a9d679b8832f8e29cea142acde68