### PR TITLE
Use current origin as default API base URL

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,5 +1,4 @@
 export const API_BASE_URL =
   (typeof import.meta !== 'undefined' && import.meta.env && (import.meta.env.VITE_API_BASE_URL || import.meta.env.API_BASE_URL)) ||
   (typeof process !== 'undefined' && process.env && process.env.API_BASE_URL) ||
-  (typeof window !== 'undefined' && window.API_BASE_URL) ||
-  'http://127.0.0.1:4000';
+  (typeof window !== 'undefined' && (window.API_BASE_URL || window.location.origin));


### PR DESCRIPTION
## Summary
- Default API URL to `window.location.origin` so frontend served via backend shares the same host and port
- Keep overrides via `VITE_API_BASE_URL`, `process.env.API_BASE_URL`, or `window.API_BASE_URL`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b4e05e58832f924cdec63734b71a