### PR TITLE
Define API base URL in frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,6 +176,7 @@
 
 
   <!-- Lógica de la app -->
+  <script>window.API_BASE_URL = "http://127.0.0.1:4000";</script>
   <script type="module" src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Expose API base URL on window before loading main script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bc2fe1c8832f9f312230b4e88029